### PR TITLE
Improvement: Warn users about epub conversion

### DIFF
--- a/epubmg_interfaceplugin/action.py
+++ b/epubmg_interfaceplugin/action.py
@@ -85,7 +85,7 @@ class InterfacePlugin(InterfaceAction):
         self.menu.addSeparator()
 
         # Add remove metaguiding action to menu
-        remove_metaguiding_action = self.menu.addAction(_("Remove metaguiding")) # type: ignore # noqa
+        remove_metaguiding_action = self.menu.addAction(_("Remove metaguiding"))  # type: ignore # noqa
         remove_metaguiding_action.triggered.connect(
             self.remove_metaguiding_epub_selection
         )
@@ -153,7 +153,9 @@ class InterfacePlugin(InterfaceAction):
                 )
 
                 try:
-                    metaguiding.metaguide_epub_file(temp_file, temp_file, remove_metaguiding = remove_metaguiding)
+                    metaguiding.metaguide_epub_file(
+                        temp_file, temp_file, remove_metaguiding=remove_metaguiding
+                    )
                 except Exception as e:  # pylint: disable=broad-except
                     common.log.error(
                         "Error processing book id: %d, format: %s"

--- a/epubmg_interfaceplugin/action.py
+++ b/epubmg_interfaceplugin/action.py
@@ -85,7 +85,7 @@ class InterfacePlugin(InterfaceAction):
         self.menu.addSeparator()
 
         # Add remove metaguiding action to menu
-        remove_metaguiding_action = self.menu.addAction(_("Remove metaguiding"))
+        remove_metaguiding_action = self.menu.addAction(_("Remove metaguiding")) # type: ignore # noqa
         remove_metaguiding_action.triggered.connect(
             self.remove_metaguiding_epub_selection
         )

--- a/epubmg_interfaceplugin/action.py
+++ b/epubmg_interfaceplugin/action.py
@@ -81,6 +81,9 @@ class InterfacePlugin(InterfaceAction):
         kepub_action = self.menu.addAction(_("Metaguide kepub"))  # type: ignore # noqa
         kepub_action.triggered.connect(self.metaguide_kepub_selection)
 
+        # Add separator
+        self.menu.addSeparator()
+
         # Add remove metaguiding action to menu
         remove_metaguiding_action = self.menu.addAction(_("Remove metaguiding"))
         remove_metaguiding_action.triggered.connect(

--- a/epubmg_interfaceplugin/action.py
+++ b/epubmg_interfaceplugin/action.py
@@ -113,6 +113,19 @@ class InterfacePlugin(InterfaceAction):
                 default_yes=False,
             ):
                 return
+        else:
+            if not question_dialog(
+                self.gui,
+                "Metaguiding will modify your files",
+                "This feature will modify your files by adding metaguiding to them. "
+                "The original file will be saved as ORIGINAL_format (ex: ORIGINAL_EPUB), and the new file will overwrite the original file. "
+                "Any previous ORIGINAL_format file will be overwritten and lost. "
+                "Please make sure to backup your library before using this feature.\n\n"
+                "Do you want to continue?",
+                show_copy_button=True,
+                default_yes=False,
+            ):
+                return
 
         action_text = "remove metaguiding" if remove_metaguiding else "add metaguiding"
 
@@ -137,7 +150,7 @@ class InterfacePlugin(InterfaceAction):
                 )
 
                 try:
-                    metaguiding.metaguide_epub_file(temp_file, temp_file)
+                    metaguiding.metaguide_epub_file(temp_file, temp_file, remove_metaguiding = remove_metaguiding)
                 except Exception as e:  # pylint: disable=broad-except
                     common.log.error(
                         "Error processing book id: %d, format: %s"


### PR DESCRIPTION
Introduce a warning dialog to inform users that converting an epub will overwrite the original file and that the only way to revert is to restore the original. Additionally, add a separator in the menu before the remove metaguiding action for better organization and ensure code consistency.

Fixes #3